### PR TITLE
Support boolean values for boolean attributes

### DIFF
--- a/src/Hyperscript.jl
+++ b/src/Hyperscript.jl
@@ -196,6 +196,11 @@ function render(io::IO, rctx::RenderContext, ctx::HTMLSVG, node::Node{HTMLSVG})
     end
     printescaped(io, tag(node), etag)
     for (name, value) in pairs(attrs(node))
+        if isboolattr(name)
+            value isa Bool || error("Boolean attribute \"$(name)\" expects `Bool`, found `$(typeof(value))`: $(stringify(ctx, tag(node), name => value))")
+            value = value ? "" : continue
+        end
+
         print(io, " ")
         printescaped(io, name, eattrname)
         if value != nothing
@@ -222,6 +227,37 @@ function render(io::IO, rctx::RenderContext, ctx::HTMLSVG, node::Node{HTMLSVG})
         print(io, ">")
     end
 end
+
+const BOOL_ATTRS = Set([
+    "allowfullscreen",
+    "allowpaymentrequest",
+    "async",
+    "autofocus",
+    "autoplay",
+    "checked",
+    "controls",
+    "default",
+    "defer",
+    "disabled",
+    "formnovalidate",
+    "hidden",
+    "ismap",
+    "itemscope",
+    "loop",
+    "multiple",
+    "muted",
+    "nomodule",
+    "novalidate",
+    "open",
+    "playsinline",
+    "readonly",
+    "required",
+    "reversed",
+    "selected",
+    "truespeed",
+    "typemustmatch"
+])
+isboolattr(attr::AbstractString) = attr in BOOL_ATTRS
 
 const VOID_TAGS = Set([
     "track", "hr", "col", "embed", "br", "circle", "input", "base",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,6 +63,12 @@ end
 # Passing a string as an attribute name preserves it un-normalized
 @renders Hyperscript.Node(Hyperscript.DEFAULT_HTMLSVG_CONTEXT, "p", [], ["camelName" => 7.0]) s`<p camelName="7.0"></p>`
 
+# Support boolean values for boolean attributes
+@renders m("input", type="checkbox", checked=true) s`<input checked="" type="checkbox" />`
+@renders m("input", type="checkbox", checked=false) s`<input type="checkbox" />`
+# @errors m("input", type="checkbox", checked="true")
+@renders m("input", type="text", value=true) s`<input value="true" type="text" />`
+
 ## Children
 # Can render children
 @renders m("p", "child") s`<p>child</p>`


### PR DESCRIPTION
Fix #20. Implemented as suggested in [comment](https://github.com/JuliaWeb/Hyperscript.jl/issues/20#issuecomment-590560901):

```julia
julia> using Hyperscript

julia> m("input", type="checkbox", checked=true)
<input checked="" type="checkbox" />

julia> m("input", type="checkbox", checked=false)
<input type="checkbox" />

julia> m("input", type="text", value=true)  # as string if not a boolean attribute
<input value="true" type="text" />

julia> m("input", type="checkbox", checked="true")  # boolean attributes expect booleans
<inputError showing value of type Hyperscript.Node{Hyperscript.HTMLSVG}:
ERROR: Boolean attribute "checked" expects `Bool`, found `String`: <input> checked=true  />
Stacktrace:
  ...
```