### PR TITLE
kebab function fix

### DIFF
--- a/src/Hyperscript.jl
+++ b/src/Hyperscript.jl
@@ -179,8 +179,8 @@ printescaped(io::IO, x::AbstractChar, escapes) = printescaped(io, string(x), esc
 # allocation via sprint. future use: sprint(printescaped, x, escapes))
 printescaped(io::IO, x, escapes) = printescaped(io, sprint(print, x), escapes)
 
-# pass numbers through untrammelled
-kebab(camel::String) = join(islowercase(c) || isnumeric(c) || c == '-' ? c : '-' * lowercase(c) for c in camel)
+# pass numbers (and 1-character attributes) through untrammelled
+kebab(camel::String) = length(camel) > 1 ? join(islowercase(c) || isnumeric(c) || c == '-' ? c : '-' * lowercase(c) for c in camel) : camel
 
 
 ## HTMLSVG


### PR DESCRIPTION
When trying to create an attribute with the key "\_", the kebab function used for the attribute name normalization caused the "\_" name to be mapped to "-\_".

However, even if the input starts with a upper case character, the mapping from "T" to "-t" doesn't make much sense.

My use case involved the usage of [_hyperscript (js)](https://hyperscript.org/docs/) package where the events are created by defining the "\_" attribute.

This small fix prevents the function to alter the 1-character inputs.



