### PR TITLE
Release 1.0.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Hyperscript"
 uuid = "47d2ed2b-36de-50cf-bf87-49c2cf4b8b91"
 author = ["Yuri Vishnevsky <yurivish@gmail.com>"]
-version = "0.0.5"
+version = "1.0.0"
 
 [deps]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Let's release 1.0.0 (or at least 0.1.0) so we can use semver. (Right now every release is a breaking release.)

I also don't feel like this package is in a `0.0.x` state.