### PR TITLE
Make kebab(camel) just never touch the first letter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ##Changes
 
-Besides fixing the camelcase algorithm for initial caps, I have removed all escapes everywhere for everything. Remember to add them back one at a time if problems show up.
+Besides fixing the camelcase algorithm for initial caps, which i PR'd, I have removed all escapes everywhere for everything. Remember to add them back one at a time if problems show up.
 
 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ##Changes
 
-Besides fixing the cmelcase algorithm for initla caps, I have removed all escapes every for everything. Remember to add them back one at a time if problems show up.
+Besides fixing the camelcase algorithm for initial caps, I have removed all escapes everywhere for everything. Remember to add them back one at a time if problems show up.
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # Hyperscript
 
+##Changes
+
+Besides fixing the cmelcase algorithm for initla caps, I have removed all escapes every for everything. Remember to add them back one at a time if problems show up.
+
+
+
+
+
+
+
+
 Hyperscript is a package for working with HTML, SVG, and CSS in Julia.
 
 When using this library you automatically get:

--- a/src/Hyperscript.jl
+++ b/src/Hyperscript.jl
@@ -238,7 +238,7 @@ renderdomchild(io, rctx::RenderContext, ctx, x::Nothing) = nothing
 
 # Render and escape other HTMLSVG children, including CSS nodes, in the parent context.
 # If a child is `showable` with text/html, render with that using `repr`.
-renderdomchild(io, rctx::RenderContext, ctx, x) =
+renderdomchild(io, rctx::RenderContext, ctx, x) = 
     showable(MIME("text/html"), x) ? show(io, MIME("text/html"), x) : printescaped(io, x, escapechild(ctx))
 
 # All camelCase attribute names from HTML 4, HTML 5, SVG 1.1, SVG Tiny 1.2, and SVG 2
@@ -315,13 +315,12 @@ chardict(chars) = Dict(c => "&#$(Int(c));" for c in chars)
 const NO_ESCAPES = Dict{Char, String}()
 
 # See: https://stackoverflow.com/questions/7753448/how-do-i-escape-quotes-in-html-attribute-values
-const ATTR_VALUE_ESCAPES = chardict("&<>\"\n\r\t")
-#
+const ATTR_VALUE_ESCAPES = NO_ESCAPES
+#chardict("&<>\"\n\r\t")
 
 # See: https://stackoverflow.com/a/9189067/1175713
-const HTML_ESCAPES =  chardict("&<>\"'`!@\$%()=+{}[]")
-# NO_ESCAPES
-
+const HTML_ESCAPES = NO_ESCAPES
+# chardict("&<>\"'`!@\$%()=+{}[]")
 
 
 

--- a/src/Hyperscript.jl
+++ b/src/Hyperscript.jl
@@ -238,7 +238,7 @@ renderdomchild(io, rctx::RenderContext, ctx, x::Nothing) = nothing
 
 # Render and escape other HTMLSVG children, including CSS nodes, in the parent context.
 # If a child is `showable` with text/html, render with that using `repr`.
-renderdomchild(io, rctx::RenderContext, ctx, x) = 
+renderdomchild(io, rctx::RenderContext, ctx, x) =
     showable(MIME("text/html"), x) ? show(io, MIME("text/html"), x) : printescaped(io, x, escapechild(ctx))
 
 # All camelCase attribute names from HTML 4, HTML 5, SVG 1.1, SVG Tiny 1.2, and SVG 2
@@ -315,12 +315,13 @@ chardict(chars) = Dict(c => "&#$(Int(c));" for c in chars)
 const NO_ESCAPES = Dict{Char, String}()
 
 # See: https://stackoverflow.com/questions/7753448/how-do-i-escape-quotes-in-html-attribute-values
-const ATTR_VALUE_ESCAPES = NO_ESCAPES
-#chardict("&<>\"\n\r\t")
+const ATTR_VALUE_ESCAPES = chardict("&<>\"\n\r\t")
+#
 
 # See: https://stackoverflow.com/a/9189067/1175713
-const HTML_ESCAPES = NO_ESCAPES
-# chardict("&<>\"'`!@\$%()=+{}[]")
+const HTML_ESCAPES =  chardict("&<>\"'`!@\$%()=+{}[]")
+# NO_ESCAPES
+
 
 
 

--- a/src/Hyperscript.jl
+++ b/src/Hyperscript.jl
@@ -180,7 +180,7 @@ printescaped(io::IO, x::AbstractChar, escapes) = printescaped(io, string(x), esc
 printescaped(io::IO, x, escapes) = printescaped(io, sprint(print, x), escapes)
 
 # pass numbers (and 1-character attributes) through untrammelled
-kebab(camel::String) = length(camel) > 1 ? join(islowercase(c) || isnumeric(c) || c == '-' ? c : '-' * lowercase(c) for c in camel) : camel
+kebab(camel::String) = camel[1] * join(islowercase(c) || isnumeric(c) || c == '-' ? c : '-' * lowercase(c) for c in camel[2:end])
 
 
 ## HTMLSVG

--- a/src/Hyperscript.jl
+++ b/src/Hyperscript.jl
@@ -311,14 +311,18 @@ end
 # Creates an HTML or SVG escaping dictionary
 chardict(chars) = Dict(c => "&#$(Int(c));" for c in chars)
 
-# See: https://stackoverflow.com/questions/7753448/how-do-i-escape-quotes-in-html-attribute-values
-const ATTR_VALUE_ESCAPES = chardict("&<>\"\n\r\t")
-
-# See: https://stackoverflow.com/a/9189067/1175713
-const HTML_ESCAPES = chardict("&<>\"'`!@\$%()=+{}[]")
-
 # Used for CSS nodes, as well as children of tag nodes defined with @tags_noescape
 const NO_ESCAPES = Dict{Char, String}()
+
+# See: https://stackoverflow.com/questions/7753448/how-do-i-escape-quotes-in-html-attribute-values
+const ATTR_VALUE_ESCAPES = NO_ESCAPES
+#chardict("&<>\"\n\r\t")
+
+# See: https://stackoverflow.com/a/9189067/1175713
+const HTML_ESCAPES = NO_ESCAPES
+# chardict("&<>\"'`!@\$%()=+{}[]")
+
+
 
 escapetag(ctx::HTMLSVG) = HTML_ESCAPES
 escapeattrname(ctx::HTMLSVG) = HTML_ESCAPES


### PR DESCRIPTION
Update Hyperscript.jl

```jl
h2.Title()
```
```html
<h2 class="-title"></h2>
```

Seems wrong, like this function is there to convert camelcase, not initial capitals.